### PR TITLE
use Authorization header for basic auth

### DIFF
--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -3,7 +3,8 @@
 
 var _       = require('underscore'),
     request = require('request'),
-    moment  = require('moment');
+    moment  = require('moment'),
+    Buffer  = require('buffer');
 
 var exports = module.exports = {};
 
@@ -62,7 +63,11 @@ var injectAuth = function(payload, headers, auth, options, callback){
         });
     }
     else{
-        payload.password = auth.password;
+        var base64BasicCredentials = Buffer.from(payload.userid + ':' + auth.password).toString('base64');
+        headers.Authorization = 'Basic ' + base64BasicCredentials;
+        delete payload.token;
+        delete payload.password;
+        delete payload.userid;
         // console.error('\nWARNING: ALKS credential authentication is deprecated, please switch to two-factor authentication (alks developer login2fa).\n');
         callback();
     }


### PR DESCRIPTION
updates the authentication logic to pass basic credentials in the Authorization header rather than in the request body so that GET request endpoints can be supported