### PR TITLE
Support max key duration

### DIFF
--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -9,12 +9,12 @@ var exports = module.exports = {};
 
 // process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0; // for testing self-signed endpoints
 
-var ALKS_DURATIONS  = [ 2, 6, 12, 18 ], // reducing due to EB not honoring long sessions: , 24, 36 ],
-    AWS_SIGNIN_URL  = 'https://signin.aws.amazon.com/federation',
-    AWS_CONSOLE_URL = 'https://console.aws.amazon.com/',
-    SANITIZE_FIELDS = [ 'password', 'refreshToken', 'accessToken', 'accessKey', 'secretKey', 'sessionToken' ],
-    DEFAULT_UA      = 'alks-node',
-    STATUS_SUCCESS  = 'success';
+var ALKS_MAX_DURATION = 18, // reducing due to EB not honoring long sessions: , 24, 36 ],
+    AWS_SIGNIN_URL    = 'https://signin.aws.amazon.com/federation',
+    AWS_CONSOLE_URL   = 'https://console.aws.amazon.com/',
+    SANITIZE_FIELDS   = [ 'password', 'refreshToken', 'accessToken', 'accessKey', 'secretKey', 'sessionToken' ],
+    DEFAULT_UA        = 'alks-node',
+    STATUS_SUCCESS    = 'success';
 
 var getMessageFromBadResponse = function(results){
     if(results.body){
@@ -68,8 +68,41 @@ var injectAuth = function(payload, headers, auth, options, callback){
     }
 };
 
-exports.getDurations = function(){
-    return ALKS_DURATIONS;
+exports.getDurations = function(account, auth, opts, callback){
+    var headers = { 'User-Agent': options.ua };
+    var options = _.extend({
+        debug: false,
+        ua:    DEFAULT_UA
+    }, opts);
+    var accountId = account.alksAccount.substring(0,12);
+    var endpoint = account.server + '/loginRoles/id/' + accountId + '/' + account.alksRole;
+
+    injectAuth(null, headers, auth, options, function(err){
+        if(err) return callback(err);
+
+        log('api:getDurations', 'getting max key duration: ' + endpoint, options);
+
+        request({
+            url: endpoint,
+            method: 'GET',
+            headers: headers
+        }, function(err, results) {
+            if(err){
+                return callback(err);
+            }
+            else if(results.statusCode !== 200){
+                return callback(new Error(getMessageFromBadResponse(results)));
+            }
+            else if(results.body.statusMessage.toLowerCase() !== STATUS_SUCCESS){
+                return callback(new Error(results.body.statusMessage));
+            }
+
+            var maxKeyDuration = Math.min(ALKS_MAX_DURATION, results.body.loginRole.maxKeyDuration);
+            var durations = [];
+            for(var i=1; i<=maxKeyDuration; i++) durations.push(i);
+            callback(null, durations);
+        });
+    });
 };
 
 exports.createKey = function(account, auth, duration, opts, callback){

--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -121,9 +121,14 @@ exports.createKey = function(account, auth, duration, opts, callback){
     });
 };
 
-exports.createIamKey = function(account, auth, opts, callback){
+exports.createIamKey = function(account, auth, duration, opts, callback){
+    if(arguments.length < 5){
+        callback = opts;
+        opts = duration;
+        duration = 1;
+    }
     var payload = _.extend({
-        sessionTime: 1,
+        sessionTime: duration,
         account: account.alksAccount,
         role: account.alksRole
     }, account),

--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -157,7 +157,7 @@ exports.createKey = function(account, auth, duration, opts, callback){
 };
 
 exports.createIamKey = function(account, auth, duration, opts, callback){
-    if(arguments.length < 5){
+    if(arguments.length < 5){ // for legacy calls to createIamKey
         callback = opts;
         opts = duration;
         duration = 1;

--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -69,6 +69,8 @@ var injectAuth = function(payload, headers, auth, options, callback){
 };
 
 exports.getDurations = function(account, auth, opts, callback){
+    if (arguments.length == 0) return [1]; // for legacy support
+
     var headers = { 'User-Agent': options.ua };
     var options = _.extend({
         debug: false,


### PR DESCRIPTION
Adds support for account/role specific max durations on keys which is a feature that is coming to ALKS soon. Basically this just updates the getDurations function to query ALKS for the maximum key duration for a given account/role and return a list from 1 to that max duration (inclusive) of valid durations.

I am aware that the ALKS CLI currently uses this library for communicating with ALKS so a PR is coming soon to update the CLI to use this new getDurations function signature