### PR TITLE
fixes a bug in getDurations

### DIFF
--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -71,11 +71,11 @@ var injectAuth = function(payload, headers, auth, options, callback){
 exports.getDurations = function(account, auth, opts, callback){
     if (arguments.length == 0) return [1]; // for legacy support
 
-    var headers = { 'User-Agent': options.ua };
     var options = _.extend({
         debug: false,
         ua:    DEFAULT_UA
     }, opts);
+    var headers = { 'User-Agent': options.ua };
     var accountId = account.alksAccount.substring(0,12);
     var endpoint = account.server + '/loginRoles/id/' + accountId + '/' + account.alksRole;
 


### PR DESCRIPTION
I moved the line that defines the headers var in `getDurations` since otherwise you get an error because `options` is undefined