### PR TITLE
Fix bugs in get durations

### DIFF
--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -3,7 +3,8 @@
 
 var _       = require('underscore'),
     request = require('request'),
-    moment  = require('moment');
+    moment  = require('moment'),
+    Buffer  = require('buffer').Buffer;
 
 var exports = module.exports = {};
 
@@ -62,7 +63,11 @@ var injectAuth = function(payload, headers, auth, options, callback){
         });
     }
     else{
-        payload.password = auth.password;
+        var base64BasicCredentials = Buffer.from(payload.userid + ':' + auth.password).toString('base64');
+        headers.Authorization = 'Basic ' + base64BasicCredentials;
+        delete payload.token;
+        delete payload.password;
+        delete payload.userid;
         // console.error('\nWARNING: ALKS credential authentication is deprecated, please switch to two-factor authentication (alks developer login2fa).\n');
         callback();
     }

--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -78,8 +78,12 @@ exports.getDurations = function(account, auth, opts, callback){
     var headers = { 'User-Agent': options.ua };
     var accountId = account.alksAccount.substring(0,12);
     var endpoint = account.server + '/loginRoles/id/' + accountId + '/' + account.alksRole;
+    var payload = _.extend({
+        account: account.alksAccount,
+        role: account.alksRole
+    }, account);
 
-    injectAuth(null, headers, auth, options, function(err){
+    injectAuth(payload, headers, auth, options, function(err){
         if(err) return callback(err);
 
         log('api:getDurations', 'getting max key duration: ' + endpoint, options);
@@ -92,14 +96,17 @@ exports.getDurations = function(account, auth, opts, callback){
             if(err){
                 return callback(err);
             }
-            else if(results.statusCode !== 200){
+            if(results.statusCode !== 200){
                 return callback(new Error(getMessageFromBadResponse(results)));
             }
-            else if(results.body.statusMessage.toLowerCase() !== STATUS_SUCCESS){
+
+            var body = JSON.parse(results.body);
+
+            if(body.statusMessage.toLowerCase() !== STATUS_SUCCESS){
                 return callback(new Error(results.body.statusMessage));
             }
 
-            var maxKeyDuration = Math.min(ALKS_MAX_DURATION, results.body.loginRole.maxKeyDuration);
+            var maxKeyDuration = Math.min(ALKS_MAX_DURATION, body.loginRole.maxKeyDuration);
             var durations = [];
             for(var i=1; i<=maxKeyDuration; i++) durations.push(i);
             callback(null, durations);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "./node_modules/.bin/mocha ./test"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes several more bugs I discovered related to getDurations, namely

* `getDurations` now passes a payload to injectAuth (which it should have to begin with but that was my mistake earlier
* `getDurations` now properly reads the response by parsing results.body as a JSON object since results.body is a string
* changes made from the `basicAuthViaHeader` branch have been merged, which it turns out are necessary for the new getDurations method since the http request to get durations is a GET request and thus can't have a request body, so all credentials have to be passed via a header