### PR TITLE
Better Error Response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+.idea/*

--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -621,7 +621,8 @@ exports.refreshTokenToAccessToken = function(account, token, opts, callback){
         }
     }, function(err, results){
         if(err){
-            return callback(err);
+            // [AM] - This is when we get a 400, which is (in ALKS Core) a bad refresh token. Should pass this error to the CLI.
+            return callback("Error: Refresh token expired. Please try to use the logout2fa and login2fa commands.");
         }
         else if(results.statusCode !== 200){
             return callback(new Error(getMessageFromBadResponse(results)));

--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -621,7 +621,7 @@ exports.refreshTokenToAccessToken = function(account, token, opts, callback){
         }
     }, function(err, results){
         if(err){
-            // [AM] - This is when we get a 400, which is (in ALKS Core) a bad refresh token. Should pass this error to the CLI.
+            // [AM] - This is when we get a 500, which is (in ALKS Core) a bad refresh token. Should pass this error to the CLI.
             return callback("Error: Refresh token expired. Please try to use the logout2fa and login2fa commands.");
         }
         else if(results.statusCode !== 200){


### PR DESCRIPTION
This small bit of code should help guide users when an expired refresh token occurs. Originally ALKS will throw a `4xx` error which in turn returns a "Failed." error message in `alks-node`. I've modified it so the error is a little clearer. 

I've also ignored `.idea/*` directories as I use Jetbrain products :)