### PR TITLE
[BUGFIX] Better error responses!

### DIFF
--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -30,6 +30,15 @@ var getMessageFromBadResponse = function(results){
     return 'Bad response received, please check API URL.';
 };
 
+var getMessageFromRefreshToAccess = function(results) {
+    if (results.body) {
+        if (results.body.errors) {
+            return results.body.errors;
+        }
+    }
+    return 'Bad response received, please check API URL.';
+}
+
 var log = function(section, msg, options){
     if(options.debug){
         console.error([ '[', section, ']: ', msg ].join(''));
@@ -621,11 +630,10 @@ exports.refreshTokenToAccessToken = function(account, token, opts, callback){
         }
     }, function(err, results){
         if(err){
-            // [AM] - This is when we get a 500, which is (in ALKS Core) a bad refresh token. Should pass this error to the CLI.
-            return callback("Error: Refresh token expired. Please try to use the logout2fa and login2fa commands.");
+            return callback(err);
         }
         else if(results.statusCode !== 200){
-            return callback(new Error(getMessageFromBadResponse(results)));
+            return callback(new Error(getMessageFromRefreshToAccess(results)));
         }
 
         if(results.body.errors && results.body.errors.length){


### PR DESCRIPTION
This PR reverts my previous attempt at getting better logging. While testing I noticed that the error block I initially thought was throwing the error was actually incorrect. This has been corrected and tested locally! 

I do propose we keep an eye on future `Error: Failed` requests, because there's a lot of endpoints using a generic function to extract the error, and some are meaningful while others will return the same generic `Failed` response. At least now we know the culprit if this comes up again.

Here's a screenshot:
![Screen Shot 2020-08-31 at 10 46 05 AM](https://user-images.githubusercontent.com/57536014/91733488-94e6a300-eb77-11ea-9662-7c59f3c32d0c.png)

**Note: Ignore the console.log, just was there for testing...but look at that meaningful message!**