### PR TITLE
Allow support for MI

### DIFF
--- a/lib/alks-api.js
+++ b/lib/alks-api.js
@@ -279,13 +279,14 @@ exports.createLongTermKey = function(account, auth, iamUserName, opts, callback)
     });
 };
 
-exports.createIamRole = function(account, auth, roleName, roleType, includeDefaultPolicies, opts, callback){
+exports.createIamRole = function(account, auth, roleName, roleType, includeDefaultPolicies, enableAlksAccess, opts, callback){
     var payload = _.extend({
         account: account.alksAccount,
         role: account.alksRole,
         roleName: roleName,
         roleType: roleType,
-        includeDefaultPolicy: includeDefaultPolicies ? '1' : '0'
+        includeDefaultPolicy: includeDefaultPolicies ? '1' : '0',
+        enableAlksAccess: enableAlksAccess
     }, account),
         options = _.extend({
             debug: false,


### PR DESCRIPTION
This fixes a bug where when we create roles we're not passing the attribute to allow a role to be a MI. This will also need some updating in `alks-cli`.